### PR TITLE
Add CR Updates, Handle Multi-Extent Directories, Examine File Flags o…

### DIFF
--- a/src/iso.c
+++ b/src/iso.c
@@ -32,8 +32,8 @@ See the file LICENSE for details.
 
 // Use these to prevent multiple fetches of the same
 // ATAPI block for consecutive, single character reads
-char global_atapi_block[ATAPI_BLOCKSIZE];
-int global_atapi_unit = -1;
+static char global_atapi_block[ATAPI_BLOCKSIZE];
+static int global_atapi_unit = -1;
 int global_atapi_extent = -1;
 
 struct iso_point {
@@ -43,13 +43,13 @@ struct iso_point {
 };
 
 static int get_directory_record(struct iso_point *iso_p, struct directory_record *dr);
-static uint32_t hex_to_int(unsigned char *src, int len);
+static uint32_t bendian_chars_to_int(unsigned char *src, int len);
 static bool is_dir(int flags);
-static bool is_valid_record(struct directory_record *dr);
-static long int iso_look_up(const char *pname, uint32_t *dl, int ata_unit);
-static long int iso_recursive_look_up (const char *pname, struct iso_point *iso_p, uint32_t *dl);
+static long int iso_look_up(const char *pname, uint32_t *dl, int ata_unit, bool is_dir_search);
+static long int iso_recursive_look_up (const char *pname, struct iso_point *iso_p, uint32_t *dl, bool is_dir_search);
 static void iso_media_close(struct iso_point *iso_p);
 static struct iso_point *iso_media_open(int ata_unit);
+static int iso_media_peek_byte(struct iso_point *iso_p);
 static int iso_media_read(void *dest, int elem_size, int num_elem, struct iso_point *stream);
 static void iso_media_seek(struct iso_point *iso_p, long offset, int whence);
 
@@ -67,7 +67,6 @@ static int get_directory_record(struct iso_point *iso_p, struct directory_record
     char dr_dest[MAX_DR_SIZE];
     int result = iso_media_read(dr_dest, 1, MAX_DR_SIZE, iso_p);
     if (result != MAX_DR_SIZE) {
-        console_printf("get directory record fails\n");
         return 0;
     }
 
@@ -99,13 +98,13 @@ static int get_directory_record(struct iso_point *iso_p, struct directory_record
 }
 
 /**
- * @brief Converts a character hex number into a base 10 integer
+ * @brief Converts a big endian character array into a base 10 integer
  *
- * @param src Array of hex characters in big endian format
+ * @param src Array of characters in big endian format
  * @param len Number of bytes in the src to convert
- * @return The integer value of the first len bytes of hex characters in src
+ * @return The integer value of the first len bytes of characters in src
  */
-static uint32_t hex_to_int(unsigned char *src, int len) {
+static uint32_t bendian_chars_to_int(unsigned char *src, int len) {
     uint32_t i, sum = 0;
     for (i = 0; i < len; i++) {
         sum *= 256;
@@ -129,27 +128,6 @@ static bool is_dir(int flags) {
     }
 }
 
-static bool is_valid_record(struct directory_record *dr) {
-     if (dr->rec_date_time[3] < 0 || dr->rec_date_time[3] >= 24) {  // validate hours
-         return 0;
-     }
-     if (dr->rec_date_time[4] < 0 || dr->rec_date_time[4] >= 60) {  // validate minutes
-         return 0;
-     }
-     if (dr->rec_date_time[5] < 0 || dr->rec_date_time[5] >= 60) {  // validate seconds
-         return 0;
-     }
-     if (dr->rec_date_time[1] <= 0 || dr->rec_date_time[1] > 12) {  // validate month
-         return 0;
-     }
-     if (dr->rec_date_time[2] <= 0 || dr->rec_date_time[2] > 31) {  // validate day
-         return 0;
-     }
-     if (dr->rec_date_time[0] < 0) {    // validate year
-         return 0;
-     }
-     return 1;
- }
 
 //Documentation in header
 int iso_dclose(struct iso_dir *dir) {
@@ -163,7 +141,7 @@ int iso_dclose(struct iso_dir *dir) {
 //Documentation in header
 struct iso_dir *iso_dopen(const char *pname, int ata_unit) {
     uint32_t dl;  //data length, needed in iso_look_up
-    int extent_num = iso_look_up(pname, &dl, ata_unit);
+    int extent_num = iso_look_up(pname, &dl, ata_unit, 1);
     if (extent_num < 0) {
         return 0;
     }
@@ -173,7 +151,6 @@ struct iso_dir *iso_dopen(const char *pname, int ata_unit) {
     struct directory_record *dr = kmalloc(sizeof(*dr));
     get_directory_record(iso_p, dr);
     if (!is_dir(dr->file_flags[0])) {
-        console_printf("Failed to open directory\n");
         return 0;
     }
     to_return->cur_offset = 0;
@@ -187,25 +164,36 @@ struct iso_dir *iso_dopen(const char *pname, int ata_unit) {
 
 //Documentation in header
 struct directory_record *iso_dread(struct iso_dir *read_from) {
-    if (read_from->cur_offset + 1 >= read_from->data_length) {
-        //"return null" if at end of directory record
-        return 0;
-    }
+    int num_extents_in_directory = read_from->data_length / ATAPI_BLOCKSIZE;
+    int final_extent_of_directory = read_from->extent_offset + (num_extents_in_directory - 1);
 
     struct iso_point *iso_p = iso_media_open(read_from->ata_unit);
 
     // seek to current offset of iso_p
     iso_media_seek(iso_p, read_from->extent_offset * ATAPI_BLOCKSIZE + read_from->cur_offset, SEEK_SET);
+    if (iso_media_peek_byte(iso_p) == 0) {
+        //No more records on this extent, but are there more on next extent?
+        if (iso_p->cur_extent < final_extent_of_directory) {
+            iso_media_seek(iso_p, (iso_p->cur_extent + 1) * ISO_BLOCKSIZE, SEEK_SET);
+            read_from->cur_offset = ISO_BLOCKSIZE * (iso_p->cur_extent - read_from->extent_offset);
+        }
+        else {
+            //End of this directory, return null
+            iso_media_close(iso_p);
+            return 0;
+        }
+    }
+
     struct directory_record *next_dr = kmalloc(sizeof(*next_dr));
 
-    //if not the end of the directory record, fill the dest by dereferencing dest_ptr
+    //Not at the end of the directory record, fill the dest by dereferencing dest_ptr
     int success = get_directory_record(iso_p, next_dr);
     if (!success) {
         iso_media_close(iso_p);
         return 0;
     }
 
-    read_from->cur_offset = iso_p->cur_offset;
+    read_from->cur_offset = iso_p->cur_offset + (iso_p->cur_extent - read_from->extent_offset) * ISO_BLOCKSIZE;
     //no need to reset extent, that shouldn't be an issue
     iso_media_close(iso_p);
     return next_dr;
@@ -225,9 +213,8 @@ struct iso_file *iso_fopen(const char *pname, int ata_unit) {
     struct iso_file *file = kmalloc(sizeof(struct iso_file));
     strcpy(file->pname, pname);
     uint32_t dl;  //the data_length of the last item on the path
-    int file_offset = iso_look_up(pname, &dl, ata_unit);
+    int file_offset = iso_look_up(pname, &dl, ata_unit, 0);
     if (file_offset < 0) {
-        console_printf("Failed to iso_open the file path \"%s\".\n", pname);
         return 0;
     }
     file->cur_offset = 0;
@@ -247,7 +234,6 @@ int iso_fread(void *dest, int elem_size, int num_elem, struct iso_file *file) {
     int bytes_to_disk_read = elem_size * num_elem;
     int bytes_to_file_read = bytes_to_disk_read;
     if ((bytes_to_file_read + file->cur_offset) > file->data_length) {
-
         // Don't actually want to read off the end of the file
         bytes_to_file_read = file->data_length - file->cur_offset + 1;
         bytes_to_disk_read = bytes_to_file_read - 1;
@@ -255,7 +241,6 @@ int iso_fread(void *dest, int elem_size, int num_elem, struct iso_file *file) {
     }
     int bytes_read = iso_media_read(dest, 1, bytes_to_disk_read, iso_p);
     if (bytes_read != bytes_to_disk_read) {
-        console_printf("file reading error\n");
         iso_media_close(iso_p);
         return -1;
     }
@@ -270,7 +255,6 @@ int iso_fread(void *dest, int elem_size, int num_elem, struct iso_file *file) {
  * @details Frees the iso_point that was used to navigate the ISO disk.
  *
  * @param iso_p A pointer to the iso_point to close.
- * @return Pointer to an allocated iso_point with members initialized to 0
  */
 static void iso_media_close(struct iso_point *iso_p) {
     kfree(iso_p);
@@ -294,6 +278,21 @@ static struct iso_point *iso_media_open(int ata_unit) {
 }
 
 /**
+ * @brief Peek at the next byte on the iso media
+ * @details Read the next byte at the current extent and offset of iso_p, then
+ * iso_seek back one byte. iso_p is unchanged after the call.
+ *
+ * @param iso_p Pointer to the iso_point we're peeking at.
+ * @return The value of the byte iso_p is set to read next.
+ */
+static int iso_media_peek_byte(struct iso_point *iso_p) {
+    uint8_t byte;
+    iso_media_read(&byte, 1, 1, iso_p);
+    iso_media_seek(iso_p, -1, SEEK_CUR);
+    return byte;
+}
+
+/**
  * @brief Reads in the specified amount from the iso_p
  * @details Reads into dest the specified amount from the iso starting
  * at the current extent and offset of iso_p
@@ -301,7 +300,7 @@ static struct iso_point *iso_media_open(int ata_unit) {
  * @param dest A buffer to put the read information into
  * @param elem_size The size in bytes of each element to be read
  * @param num_elem The number of elements to read into dest
- * @param iso_p Pointer to the struct iso_point to begin reading at.
+ * @param stream Pointer to the struct iso_point to begin reading at.
  * @return The number of elements read in, -1 on error.
  */
 static int iso_media_read(void *dest, int elem_size, int num_elem, struct iso_point *stream) {
@@ -310,10 +309,11 @@ static int iso_media_read(void *dest, int elem_size, int num_elem, struct iso_po
         return 0;
     }
 
-    int to_read_from_start_of_cur_extent = stream->cur_offset + bytes_needed;
-    int atapi_blocks_to_read = to_read_from_start_of_cur_extent / ATAPI_BLOCKSIZE;
+    // the number of bytes into the current extent which we need to stop at
+    int last_byte_cur_extent = stream->cur_offset + bytes_needed;
+    int atapi_blocks_to_read = last_byte_cur_extent / ATAPI_BLOCKSIZE;
 
-    if (to_read_from_start_of_cur_extent % ATAPI_BLOCKSIZE) {
+    if (last_byte_cur_extent % ATAPI_BLOCKSIZE) {
         //integer division rounds down, but we need to round up
         //if there is rounding to be done
         atapi_blocks_to_read++;
@@ -325,7 +325,6 @@ static int iso_media_read(void *dest, int elem_size, int num_elem, struct iso_po
         global_atapi_unit != stream->ata_unit) {
         char buffer[atapi_blocks_to_read * ATAPI_BLOCKSIZE];
         if (!atapi_read(stream->ata_unit, buffer, atapi_blocks_to_read, stream->cur_extent)) {
-            console_printf("atapi_read is 0 in iso_media_read()\n");
             return -1;
         } else {
             //Do not start at the start of the buffer, because that is the start of
@@ -383,43 +382,53 @@ static void iso_media_seek(struct iso_point *iso_p, long offset, int whence) {
             }
             break;
         default:
-            console_printf("Illegal iso_seek mode\n");
             break;
     }
 }
 
 /**
- * @brief Lookup offset the dir/file requested
+ * @brief Lookup offset of the dir/file requested
  * @details Finds the offset of the file or directory named by
  * the full pathname starting at the root of the iso filesystem
  * (no relative paths allowed).
  *
- * @param pathname The string name of file or directory to lookup (with no leading /)
- * @param offset The extent number to search the
+ * @param pname The string name of file or directory to lookup (requires leading /)
+ * @param dl Pointer to integer to fill in indicating dir/file data length
+ * @param ata_unit The ata_unit to search for the dir/file on
+ * @param is_dir_search 1 if we are looking up a directory, 0 if a file
  * @return Offset (extent number) of the pathname, or -1 if not found or error
  */
-static long int iso_look_up(const char *pname, uint32_t *dl, int ata_unit) {
+static long int iso_look_up(const char *pname, uint32_t *dl, int ata_unit, bool is_dir_search) {
     int root_dr_loc;
     struct iso_point *iso_p = iso_media_open(ata_unit);
     //locate the root directory
     iso_media_seek(iso_p, ROOT_DR_OFFSET, SEEK_SET);
 
+    //Read root directory record from PVD
     struct directory_record dr;
     unsigned char loc_of_parent[8];
     int success = get_directory_record(iso_p, &dr);
     if (!success) {
+        iso_media_close(iso_p);
         return -1;
     }
 
     memcpy(&loc_of_parent, dr.loc_of_ext, 8);
-    root_dr_loc = hex_to_int(loc_of_parent + 4, 4);
+    root_dr_loc = bendian_chars_to_int(loc_of_parent + 4, 4);
 
     if (strcmp(pname, "/") == 0) {
-        return root_dr_loc;
-    } else {
+        iso_media_close(iso_p);
+        if (is_dir_search) {
+            return root_dr_loc;
+        }
+        else {  //Tried to open "/" as file
+            return -1;
+        }
+    }
+    else {
         iso_media_seek(iso_p, root_dr_loc * ISO_BLOCKSIZE, SEEK_SET);
         //moving forward, get rid of the first slash and give the iso_p we already seek'd for
-        long int result = iso_recursive_look_up(&pname[1], iso_p, dl);
+        long int result = iso_recursive_look_up(&pname[1], iso_p, dl, is_dir_search);
         iso_media_close(iso_p);
         return result;
     }
@@ -432,11 +441,13 @@ static long int iso_look_up(const char *pname, uint32_t *dl, int ata_unit) {
  * by looking at the directory record given by the current
  * disk offset, but does not handle the case of root.
  *
- * @param pathname The string name of file or directory to lookup (with no leading /)
- * @param offset The extent number to search the
+ * @param pname The string name of file or directory to lookup (with no leading /)
+ * @param iso_p Pointer to the iso point of the start of the directory extent to search.
+ * @param dl Pointer to integer to fill in indicating dir/file data length
+ * @param is_dir_search 1 if we are looking up a directory, 0 if a file
  * @return The extent offset for the pname, or -1 if not found or on error
  */
-static long int iso_recursive_look_up (const char *pname, struct iso_point *iso_p, uint32_t *dl) {
+static long int iso_recursive_look_up (const char *pname, struct iso_point *iso_p, uint32_t *dl, bool is_dir_search) {
     int next_is_found = 0;
 
     //Find the location of the next slash in pname
@@ -462,9 +473,31 @@ static long int iso_recursive_look_up (const char *pname, struct iso_point *iso_
     identifier_to_find[next_slash_index] = 0;
     char name[strlen(pname) + 1];
     struct directory_record dr;
+
+    //add number of extents - 1 to the index of the first extent to get the final
+    //extent we should be reading for this directory (in the case where there are
+    //lots of files and it takes more than 1 extent to describe the directory)
+    int num_extents_in_directory = bendian_chars_to_int(self_dr.data_length + 4, 4) / ATAPI_BLOCKSIZE;
+    int final_extent_of_directory = bendian_chars_to_int(self_dr.loc_of_ext + 4, 4) + (num_extents_in_directory - 1);
     while (!next_is_found) {
-        success = get_directory_record(iso_p, &dr);
-        if (!success || !is_valid_record(&dr)) {
+        if (iso_media_peek_byte(iso_p) == 0) {
+            //This extent has no more directory records, as next byte
+            //should be the record_length of the next directory record
+            //between 34 and 64, but extra space at end of extent is 0'd out.
+            if (final_extent_of_directory == iso_p->cur_extent) {
+                //And we're on the final extent, desired path not found
+                return -1;
+            }
+            else {
+                //Move to the next extent and continue searching this directory.
+                iso_media_seek(iso_p, (iso_p->cur_extent + 1) * ISO_BLOCKSIZE, SEEK_SET);
+                continue;
+            }
+        }
+
+        if (!get_directory_record(iso_p, &dr)) {
+            //Failed to read disk somehow
+            //Legality of dr already guaranteed by above iso_media_peek_byte()
             return -1;
         }
 
@@ -481,14 +514,31 @@ static long int iso_recursive_look_up (const char *pname, struct iso_point *iso_
         return -1;
     }
 
-    int entity_location = hex_to_int(dr.loc_of_ext + 4, 4);
+    int entity_location = bendian_chars_to_int(dr.loc_of_ext + 4, 4);
     if (strcmp(identifier_to_find, pname) == 0) {
         //If this is the last item we're searching for
         //return it's location as an extent number, and say how long it is
-        *dl = hex_to_int(dr.data_length + 4, 4);
-        return entity_location;
-    } else {
+        if (is_dir_search) {
+            if (is_dir(dr.file_flags[0])) {
+                *dl = bendian_chars_to_int(dr.data_length + 4, 4);
+                return entity_location;
+            }
+            else {  //Tried to open directory, but found file
+                return -1;
+            }
+        }
+        else {  //looking for a file
+            if (!is_dir((int)dr.file_flags[0])) {  //it is a file (it's not a dir)
+                *dl = bendian_chars_to_int(dr.data_length + 4, 4);
+                return entity_location;
+            }
+            else {  //Tried to open file, but found dir in its place
+                return -1;
+            }
+        }
+    }
+    else {
         iso_media_seek(iso_p, entity_location * ISO_BLOCKSIZE, SEEK_SET);
-        return iso_recursive_look_up(pname + next_slash_index + 1, iso_p, dl);
+        return iso_recursive_look_up(pname + next_slash_index + 1, iso_p, dl, is_dir_search);
     }
 }

--- a/src/iso.h
+++ b/src/iso.h
@@ -30,14 +30,14 @@ struct directory_record {
     uint8_t length_of_record;
     uint8_t length_of_ext_record;
     unsigned char loc_of_ext[8];   //Characters of hex for location of extent, first 4 are little endian, second 4 are big endian
-    unsigned char data_length[8];  //Characters of hex for the length of the directory record, first 4 are little endian, second 4 are big endian
-    uint8_t rec_date_time[7];   // timestamp of last modification
+    unsigned char data_length[8];  //Characters of hex for the length of the entity, first 4 are little endian, second 4 are big endian
+    uint8_t rec_date_time[7];   // time stamp of last modification
     char file_flags[1];
     char file_flags_interleaved[1];
     uint8_t interleave_gap_size;
     char vol_seq_num[4];
     uint8_t len_identifier;
-    char file_identifier[31];  //max file id with extent is 30, +1 for null
+    char file_identifier[32];  //max file id with extension is 30, max directory name is 31, +1 for null
 };
 
 /**
@@ -75,8 +75,8 @@ int iso_fread(void *dest, int elem_size, int num_elem, struct iso_file *file);
 
 /**
  * @brief Opens the directory specified
- * @details Attempts to find and open the directory specified by the pname on the given ata_unit,
- * calls kmalloc to create return value
+ * @details Attempts to find and open the directory specified by the absolute pname on the given ata_unit,
+ * calls kmalloc to create return value. No relative paths allowed.
  *
  * @param pname The absolute path name to search for the directory at
  * @param ata_unit The ata unit to search for the directory on


### PR DESCRIPTION
…n [d|f]open

Cover multiple extents for dread and for iso_recursive_lookup
Remove is_valid_record and replace with iso_byte_peek to check ahead for a good record
Examine file flags on iso_dopen, iso_fopen
Implement updates based on CR comments
Rename hex_to_int to bendian_chars_to_int

Checked by using iso_dopen and dread on both files and directories, and iso_fopen and fread on both files and directories, on file systems with a 64 sub-directories in a single directory to ensure that that directory's information wrapped to a second extent.
